### PR TITLE
Initial functionality:

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -1,0 +1,102 @@
+var SIDEBAR_TITLE = 'CKAN Data Explorer';
+var CACHE_PERIOD = 300; // cache for 5 minutes
+
+/**
+ * Adds a custom menu with items to show the sidebar
+ *
+ * @param {Object} e The event parameter for a simple onOpen trigger.
+ */
+function onOpen(e) {
+  SpreadsheetApp.getUi()
+  .createAddonMenu()
+  .addItem('Open', 'showSidebar')
+  .addToUi();
+}
+
+/**
+ * Show the side bar
+ */
+function showSidebar() {
+  var ui = HtmlService.createTemplateFromFile('Sidebar')
+      .evaluate()
+      .setTitle(SIDEBAR_TITLE)
+      .setSandboxMode(HtmlService.SandboxMode.IFRAME);
+  SpreadsheetApp.getUi().showSidebar(ui);
+  
+}
+
+/**
+ * Returns the list of package ids with a given provider url
+ * TODO: map provider to url. Currently we only have the correct url for city of Toronto
+ *
+ * @param {String} providerUrl
+ * @returns {String[]} 
+ */
+function getPackageList(providerUrl) {
+  providerUrl = 'https://ckan0.cf.opendata.inter.sandbox-toronto.ca/api/3';
+  var url = providerUrl + '/action/package_list';
+  var response = UrlFetchApp.fetch(url).getContentText();
+  return JSON.parse(response).result;
+}
+
+/**
+ * Returns the data set with the description and list of data belong to the package
+ * @param {Object} provider The provider contains the name and url
+ * @param {String} packageId Unique identifier for the package
+ * @returns {Object} packageContent
+ */
+function getDataSet(provider, packageId) {
+  // TODO: provider data with url and name should be provided by CKAN instances or when user add a provider
+  provider = {
+    url:'https://ckan0.cf.opendata.inter.prod-toronto.ca/api/3',
+    name: 'city-of-toronto'
+  };
+  // Reduce the number of times we need to fetch data by using the cache service
+  // Ref: https://developers.google.com/apps-script/guides/support/best-practices
+  var cache = CacheService.getScriptCache();
+  var cachedPackageId = provider.name + '-' + packageId;
+  var cachedPackageContent = cache.get(cachedPackageId);
+  if (cachedPackageContent != null) {
+    return JSON.parse(cachedPackageContent).result;
+  }
+
+  var url = provider.url + '/action/package_show?id=' + packageId;
+  var response = UrlFetchApp.fetch(url).getContentText();
+  cache.put(cachedPackageId, response, CACHE_PERIOD);
+  return JSON.parse(response).result;
+}  
+  
+/**
+ * Import all the data with CSV format, create a new sheet for each data set
+ * @param {Object} provider The provider contains the name and url
+ * @param {String} packageId Unique identifier for the package
+ */
+function showDataSet(provider, packageId) {
+  provider = {
+    url:'https://ckan0.cf.opendata.inter.prod-toronto.ca/api/3',
+    name: 'city-of-toronto'
+  };
+   var packageResources = getDataSet(provider, packageId).resources;
+  var spreadsheet = null;
+  for (var i = 0; i < packageResources.length; i++) {
+    // TODO: Deal with non CSV packages
+    if (packageResources[i].format == 'CSV') {
+      // create a new spreadsheet with the data name
+      spreadsheet = SpreadsheetApp.getActiveSpreadsheet().insertSheet(packageResources[i].name);
+      importCSVFromWeb(spreadsheet, packageResources[i].url);
+    }
+  }
+}
+
+/**
+ * Load into the spreadsheet with provided full URL of the CSV file
+ * @param {Object} spreadsheet
+ * @param {String} csvUrl
+ */
+function importCSVFromWeb(spreadsheet, csvUrl) {
+  var csvContent = UrlFetchApp.fetch(csvUrl).getContentText();
+  var csvData = Utilities.parseCsv(csvContent);
+  //spreadsheet = SpreadsheetApp.getActiveSheet();
+  spreadsheet.getRange(1, 1, csvData.length, csvData[0].length).setValues(csvData);
+}
+

--- a/Sidebar.html
+++ b/Sidebar.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base target="_top">
+    <!-- Use a templated HTML printing scriptlet to import common stylesheet -->
+    <?!= HtmlService.createHtmlOutputFromFile('Stylesheet').getContent(); ?>
+  </head>
+  <body>
+    <!-- Below is the HTML code that defines the sidebar element structure. -->
+    <div class="sidebar branding-below">
+      <div class="block form-group">
+          <label for="providers">Open Data Provider</label>
+          <select id="providers" style="width:100%" size="5">
+            <option>City of Toronto</option>
+            <option>Ontario</option>
+            <option>Canada</option>
+          </select>
+      </div>
+      <div class="block add-provider">
+        <button>Add new provider</button>
+      </div>
+      <div class="block form-group">
+          <label for="packages">Data sets</label>
+          <select id="packages" size="5">
+          </select>
+      </div>
+      
+      <div class="block form-group">
+        <label for="description">
+          <b>Description</b>
+        </label>
+        <textarea id="description" rows="15" style="width:100%">Dataset description goes here</textarea>
+      </div>
+    
+      <div class="block">
+       <button class="blue" id = "load-data-sets">Show Me Data</button>
+      </div>
+    </div>
+    
+    <div class="sidebar bottom">
+      <span class="gray">Data powered by CKAN</span>
+    </div>
+
+    <!-- Use a templated HTML printing scriptlet to import JavaScript. -->
+    <?!= HtmlService.createHtmlOutputFromFile('SidebarJavaScript').getContent(); ?>
+  </body>
+</html>
+

--- a/SidebarJavaScript.html
+++ b/SidebarJavaScript.html
@@ -1,0 +1,62 @@
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
+<script>
+  /**
+   * Run initializations on sidebar load.
+   */
+  $(function() {
+    // Assign handler functions to elements
+    $('#providers').change(onSelectProvider);
+    $('#packages').change(onSelectPackage);
+    $('#load-data-sets').click(onLoadDataSets);
+
+  });
+
+  /**
+   * Load the package list when the a provider is selected
+   */
+  function onSelectProvider() {
+     
+    var selectedProvider = $('#providers').val();
+    google.script.run
+      .withSuccessHandler(function(packageList) {
+        // First empty the description and packages selection as we are reloading a new list of packages
+        $('#description').val('');
+        $('#packages').empty();
+        for (packageId of packageList) {
+          $('#packages').append($('<option>', {text:packageId}));
+        }
+      })
+      .getPackageList(selectedProvider);
+  }
+
+
+  /**
+   * Load the package description when a package is selected
+   */
+  function onSelectPackage() {
+     
+    var selectedPackageId = $('#packages').val();
+    google.script.run
+      .withSuccessHandler(
+        function(packageContent) {
+          // Load the description
+          $('#description').val(packageContent.notes);
+        })
+      .getDataSet(null, selectedPackageId);
+  }
+  
+  /**
+   * Load the data set for the selected package
+   */
+  function onLoadDataSets() {
+    
+    var selectedPackageId = "council-and-standing-committee-meeting-statistics";//$('#packages').val();
+    google.script.run
+      .withSuccessHandler(
+        function() {
+          alert("yes!");
+        })
+      .showDataSet(null, selectedPackageId);
+  }
+</script>
+

--- a/Stylesheet.html
+++ b/Stylesheet.html
@@ -1,0 +1,54 @@
+<!-- This CSS package applies Google styling; it should always be included. -->
+<link rel="stylesheet" href="https://ssl.gstatic.com/docs/script/css/add-ons1.css">
+<style>
+label {
+  font-weight: bold;
+  
+}
+
+.branding-below {
+  bottom: 54px;
+  top: 0;
+}
+
+.branding-text {
+  left: 7px;
+  position: relative;
+  top: 3px;
+}
+
+.logo {
+  vertical-align: middle;
+}
+
+.width-100 {
+  width: 100%;
+  box-sizing: border-box;
+  -webkit-box-sizing : border-box;‌
+  -moz-box-sizing : border-box;
+}
+
+.add-provider {
+  text-align: right;
+}
+
+#sidebar-value-block {
+  background-color: #eee;
+  border-color: #eee;
+  border-width: 5px;
+  border-style: solid;
+}
+
+#sidebar-button-bar {
+  margin-bottom: 10px;
+}
+
+#packages {
+  width: 100%
+}
+select {
+  text-align: left;
+}
+
+</style>
+


### PR DESCRIPTION
1. Show the side bar when open the CKAN Data Explorer add-on
2. Retrieve the list of package list on a selected provider - currently only city-of-toronto
3. Load the description and csv data onto the sheet on a selected package name - currently only handles CSV formatted data